### PR TITLE
fix errors with Rate Limiting lab

### DIFF
--- a/workshop/content/rate-limiting.adoc
+++ b/workshop/content/rate-limiting.adoc
@@ -25,8 +25,6 @@ gateway.networking.istio.io/customer-gateway   3h16m
 NAME                                          GATEWAYS             HOSTS   AGE
 virtualservice.networking.istio.io/customer   [customer-gateway]   [*]     3h16m
 
-NAME                                                 HOST             AGE
-destinationrule.networking.istio.io/recommendation   recommendation   36m
 ----
 
 If you have any scripts running in the bottom terminal, make sure to click
@@ -49,7 +47,7 @@ The following YAML will limit the number of concurrent requests hitting _v2_ of 
 
 [source,bash,role="execute-1"]
 ----
-sed -e "s/USERNAME/$JUPYTERHUB_USER/" /opt/app-root/workshop/content/src/istiofiles/recommendation_rate_limit.yml | oc apply -n %username%-smcp -f -
+sed -e "s/USERNAME/$JUPYTERHUB_USER/" /opt/app-root/workshop/content/src/istiofiles/recommendation_rate_limit.yml | oc apply -n %username%-tutorial -f -
 ----
 
 The YAML looks like the following:


### PR DESCRIPTION
**Problem 1:**

_Before Starting Section -_ 
In the previous lab, the destination rule for the recommendation was deleted so when the user runs
```
oc -n user1-tutorial get istio-io
```
It won't include the destination rule like the guide says

**Problem 2:**

_Rate Limiting Section -_ 
The istio resources are created in the <user>-scmp folder, rather than the <user>-tutorial folder and as a result the lab doesn't work. For example, the current script for user1 is
```
sed -e "s/USERNAME/$JUPYTERHUB_USER/" /opt/app-root/workshop/content/src/istiofiles/recommendation_rate_limit.yml \
| oc create -n user1-smcp -f -
```
it should be
```
sed -e "s/USERNAME/$JUPYTERHUB_USER/" /opt/app-root/workshop/content/src/istiofiles/recommendation_rate_limit.yml \
| oc create -n user1-tutorial -f -
```